### PR TITLE
Add env_logger to ease troubleshooting.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,4 @@ tokio-tls = { package = "tokio-native-tls", version = "0.3" }
 xmpp-parsers = "0.18"
 die = "0.2.0"
 anyhow = "1.0"
-
+env_logger = "0.9"

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,8 @@ struct MyOptions {
 
 #[tokio::main]
 async fn main() {
+    env_logger::init();
+
     let args: Vec<String> = args().collect();
 
     // Remember to skip the first argument. That's the program name.


### PR DESCRIPTION
Apparently I had an empty /etc/resolv.conf on one host due to systemd
growing pains, which I only discovered by adding the logger and seeing

> [2021-12-31T20:22:01Z WARN  trust_dns_resolver::system_conf::unix] no nameservers found in config

Without env_logger, the only output I had was an unhelpful

> could not connect to xmpp server

and changing die() to unwrap() only narrowed it down slightly to

> Connection(Resolve(ResolveError { kind: Message("No connections available") }))

One can set the environment variable RUST_LOG=debug for more verbosity.
Under the default setting it seems to be silent if nothing goes wrong.