### PR TITLE
Muc support

### DIFF
--- a/sendxmpp.toml
+++ b/sendxmpp.toml
@@ -1,4 +1,5 @@
-# jid and password exactly like this, nothing else
+# jid and password exactly like this
 
 jid = "jid@example.org"
 password = "sOmePa55W0rD"
+# nick = "foobar"  # optional nick for Multi-User Chat

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use anyhow::{anyhow, bail, Result};
 struct Config {
     jid: String,
     password: String,
+    nick: Option<String>,
 }
 
 fn parse_cfg<P: AsRef<Path>>(path: P) -> Result<Config> {
@@ -169,11 +170,12 @@ async fn main() {
 
         for recipient in recipients {
             if opts.muc {
-                let nick = {
-                    let opt = opts.nick.clone();
-                    let node = BareJid::from_str(cfg.jid.as_str()).unwrap().node;
-                    opt.or(node).die("couldn't find a nick to use")
-                };
+                let nick = opts
+                    .nick
+                    .clone()
+                    .or(cfg.nick.clone())
+                    .or_else(|| BareJid::from_str(cfg.jid.as_str()).unwrap().node)
+                    .die("couldn't find a nick to use");
                 let participant = match recipient.clone() {
                     Jid::Full(_) => die!("Invalid room address"),
                     Jid::Bare(bare) => bare.with_resource(nick.clone()),


### PR DESCRIPTION
Bare MUC support: sends join presence and the message right after. This should work on most MUCs.

This will not attempt to ensure we're properly joined nor return any error other than those returned by tokio-xmpp already.